### PR TITLE
Support for Custom Icons

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -23,7 +23,7 @@ class TagsStyler {
   final EdgeInsets tagCancelIconPadding;
 
   ///[tagCancelIcon] apply your own icon, if you want, to delete the icon
-  final Icon tagCancelIcon;
+  final Widget tagCancelIcon;
 
   TagsStyler({
     this.tagTextPadding = const EdgeInsets.all(0.0),


### PR DESCRIPTION
Changed the cancel tag icon to type Widget from Icon so as now custom image icons can be uploaded as cancelTagIcon in form of asset images.