### PR TITLE
feat: adds a feature to provide a list of already added tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ You can investigate the properties of `TagsStyler` and `TextFieldStyler` for mor
 
 ``` dart 
    TextFieldTags(
+      tags: <String>[
+         // List of tags
+         // Provide a list of tags to initialize it with a list your provided tags
+         ],
       textFieldStyler: TextFieldStyler(
           //These are properties you can tweek for customization
 
@@ -63,6 +67,7 @@ You can investigate the properties of `TagsStyler` and `TextFieldStyler` for mor
 
 ``` dart
   TextFieldTags(
+      tags: ['university', 'college', 'music', 'math'],
       tagsStyler: TagsStyler(
         tagTextStyle: TextStyle(fontWeight: FontWeight.bold),
         tagDecoration: BoxDecoration(color: Colors.blue[300], borderRadius: BorderRadius.circular(8.0), ),
@@ -76,6 +81,7 @@ You can investigate the properties of `TagsStyler` and `TextFieldStyler` for mor
 
 ``` dart
   TextFieldTags(
+      tags: ['university', 'college', 'music', 'math'],
       tagsStyler: TagsStyler(
         tagTextStyle: TextStyle(fontWeight: FontWeight.normal),
         tagDecoration: BoxDecoration(color: Colors.blue[300], borderRadius: BorderRadius.circular(0.0), ),
@@ -90,6 +96,7 @@ You can investigate the properties of `TagsStyler` and `TextFieldStyler` for mor
 ``` dart
   //The Colors for this are used from https://flutter-color-picker.herokuapp.com/
   TextFieldTags(
+      tags: ['university', 'math', 'cs', 'music'],
       tagsStyler: TagsStyler(
         tagTextStyle: TextStyle(fontWeight: FontWeight.bold, color: Colors.white), 
         tagDecoration: BoxDecoration(color: const Color.fromARGB(255,171,81,81), borderRadius: BorderRadius.circular(8.0), ),

--- a/README.md
+++ b/README.md
@@ -74,14 +74,12 @@ You can investigate the properties of `TagsStyler` and `TextFieldStyler` for mor
         tagCancelIcon: Icon(Icons.cancel, size: 18.0, color: Colors.blue[900]),
         tagPadding: const EdgeInsets.all(6.0)
      ),
-     onTag: (tag) { print(tag)},  
    )
 ```
 <img src="https://raw.githubusercontent.com/eyoeldefare/textfield_tags/master/images/i1.png" width="350">
 
 ``` dart
   TextFieldTags(
-      tags: ['university', 'college', 'music', 'math'],
       tagsStyler: TagsStyler(
         tagTextStyle: TextStyle(fontWeight: FontWeight.normal),
         tagDecoration: BoxDecoration(color: Colors.blue[300], borderRadius: BorderRadius.circular(0.0), ),
@@ -96,7 +94,6 @@ You can investigate the properties of `TagsStyler` and `TextFieldStyler` for mor
 ``` dart
   //The Colors for this are used from https://flutter-color-picker.herokuapp.com/
   TextFieldTags(
-      tags: ['university', 'math', 'cs', 'music'],
       tagsStyler: TagsStyler(
         tagTextStyle: TextStyle(fontWeight: FontWeight.bold, color: Colors.white), 
         tagDecoration: BoxDecoration(color: const Color.fromARGB(255,171,81,81), borderRadius: BorderRadius.circular(8.0), ),

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -17,7 +17,7 @@ class TextFieldTags extends StatefulWidget {
     this.onDelete,
     this.tags,
   })  : assert(tagsStyler != null || textFieldStyler != null),
-        assert((tags == null || tags.length == 0) || (tags.length > 0 && onDelete == null && onTag == null)),
+        assert((tags == null || tags.length == 0) || (onDelete == null && onTag == null)),
         super(key: key);
 
   @override
@@ -151,8 +151,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         if (value.length > 0) {
           _textEditingController.clear();
           if (!_tagsStringContent.contains(val)) {
-            if (widget.onTag != null)
-              widget.onTag(val);
+            if (widget.onTag != null) widget.onTag(val);
 
             if (!_showPrefixIcon) {
               setState(() {
@@ -177,8 +176,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
             _textEditingController.clear();
 
             if (!_tagsStringContent.contains(lastLastTag)) {
-              if (widget.onTag != null)
-                widget.onTag(lastLastTag);
+              if (widget.onTag != null) widget.onTag(lastLastTag);
 
               if (!_showPrefixIcon) {
                 setState(() {

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -38,11 +38,10 @@ class _TextFieldTagsState extends State<TextFieldTags> {
     _textFieldStyler = widget.textFieldStyler == null ? TextFieldStyler() : widget.textFieldStyler;
     _showPrefixIcon = false;
 
-    if (widget.tags != null)
-      setState(() {
-        _showPrefixIcon = true;
-        _tagsStringContent = widget.tags;
-      });
+    if (widget.tags != null) {
+      _showPrefixIcon = true;
+      _tagsStringContent = widget.tags;
+    }
   }
 
   @override

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -7,6 +7,7 @@ class TextFieldTags extends StatefulWidget {
   final TextFieldStyler textFieldStyler;
   final void Function(String tag) onTag;
   final void Function(String tag) onDelete;
+  final List<String> tags;
 
   const TextFieldTags({
     Key key,
@@ -14,6 +15,7 @@ class TextFieldTags extends StatefulWidget {
     @required this.textFieldStyler,
     this.onTag,
     this.onDelete,
+    this.tags,
   })  : assert(tagsStyler != null || textFieldStyler != null),
         super(key: key);
 
@@ -33,10 +35,14 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   void initState() {
     super.initState();
     _tagsStyler = widget.tagsStyler == null ? TagsStyler() : widget.tagsStyler;
-    _textFieldStyler = widget.textFieldStyler == null
-        ? TextFieldStyler()
-        : widget.textFieldStyler;
+    _textFieldStyler = widget.textFieldStyler == null ? TextFieldStyler() : widget.textFieldStyler;
     _showPrefixIcon = false;
+
+    if (widget.tags != null)
+      setState(() {
+        _showPrefixIcon = true;
+        _tagsStringContent = widget.tags;
+      });
   }
 
   @override
@@ -124,8 +130,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         enabledBorder: _textFieldStyler.textFieldEnabledBorder,
         prefixIcon: _showPrefixIcon == true
             ? ConstrainedBox(
-                constraints: BoxConstraints(
-                    maxWidth: MediaQuery.of(context).size.width * 0.725),
+                constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.725),
                 child: Container(
                   margin: const EdgeInsets.symmetric(horizontal: 4.0),
                   child: SingleChildScrollView(
@@ -164,8 +169,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
       },
       onChanged: (value) {
         var splitedTagsList = value.split(" ");
-        var lastLastTag =
-            splitedTagsList[splitedTagsList.length - 2].trim().toLowerCase();
+        var lastLastTag = splitedTagsList[splitedTagsList.length - 2].trim().toLowerCase();
 
         if (value.contains(" ")) {
           if (lastLastTag.length > 0) {

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -38,7 +38,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
     _textFieldStyler = widget.textFieldStyler == null ? TextFieldStyler() : widget.textFieldStyler;
     _showPrefixIcon = false;
 
-    if (widget.tags != null) {
+    if (widget.tags != null && widget.tags.isNotEmpty) {
       _showPrefixIcon = true;
       _tagsStringContent = widget.tags;
     }
@@ -73,7 +73,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
               padding: _tagsStyler.tagCancelIconPadding,
               child: GestureDetector(
                 onTap: () {
-                  if (_tagsStringContent.length == 1 && _showPrefixIcon == true) {
+                  if (_tagsStringContent.length == 1 && _showPrefixIcon) {
                     widget.onDelete(_tagsStringContent[i]);
                     setState(() {
                       _tagsStringContent.remove(_tagsStringContent[i]);
@@ -118,8 +118,8 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         isDense: _textFieldStyler.isDense,
         helperText: _textFieldStyler.helperText,
         helperStyle: _textFieldStyler.helperStyle,
-        hintText: _showPrefixIcon == false ? _textFieldStyler.hintText : null,
-        hintStyle: _showPrefixIcon == false ? _textFieldStyler.hintStyle : null,
+        hintText: !_showPrefixIcon ? _textFieldStyler.hintText : null,
+        hintStyle: !_showPrefixIcon ? _textFieldStyler.hintStyle : null,
         filled: _textFieldStyler.textFieldFilled,
         fillColor: _textFieldStyler.textFieldFilledColor,
         enabled: _textFieldStyler.textFieldEnabled,
@@ -127,7 +127,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         focusedBorder: _textFieldStyler.textFieldFocusedBorder,
         disabledBorder: _textFieldStyler.textFieldDisabledBorder,
         enabledBorder: _textFieldStyler.textFieldEnabledBorder,
-        prefixIcon: _showPrefixIcon == true
+        prefixIcon: _showPrefixIcon
             ? ConstrainedBox(
                 constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.725),
                 child: Container(
@@ -150,7 +150,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         if (value.length > 0) {
           _textEditingController.clear();
           if (!_tagsStringContent.contains(val)) {
-            if (_showPrefixIcon == false) {
+            if (!_showPrefixIcon) {
               widget.onTag(val);
               setState(() {
                 _tagsStringContent.add(val);
@@ -175,7 +175,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
             _textEditingController.clear();
 
             if (!_tagsStringContent.contains(lastLastTag)) {
-              if (_showPrefixIcon == false) {
+              if (!_showPrefixIcon) {
                 widget.onTag(lastLastTag);
                 setState(() {
                   _tagsStringContent.add(lastLastTag);

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -17,6 +17,7 @@ class TextFieldTags extends StatefulWidget {
     this.onDelete,
     this.tags,
   })  : assert(tagsStyler != null || textFieldStyler != null),
+        assert((tags == null || tags.length == 0) || (tags.length > 0 && onDelete == null && onTag == null)),
         super(key: key);
 
   @override
@@ -73,14 +74,14 @@ class _TextFieldTagsState extends State<TextFieldTags> {
               padding: _tagsStyler.tagCancelIconPadding,
               child: GestureDetector(
                 onTap: () {
+                  if (widget.onDelete != null) widget.onDelete(_tagsStringContent[i]);
+
                   if (_tagsStringContent.length == 1 && _showPrefixIcon) {
-                    widget.onDelete(_tagsStringContent[i]);
                     setState(() {
                       _tagsStringContent.remove(_tagsStringContent[i]);
                       _showPrefixIcon = false;
                     });
                   } else {
-                    widget.onDelete(_tagsStringContent[i]);
                     setState(() {
                       _tagsStringContent.remove(_tagsStringContent[i]);
                     });
@@ -150,14 +151,15 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         if (value.length > 0) {
           _textEditingController.clear();
           if (!_tagsStringContent.contains(val)) {
-            if (!_showPrefixIcon) {
+            if (widget.onTag != null)
               widget.onTag(val);
+
+            if (!_showPrefixIcon) {
               setState(() {
                 _tagsStringContent.add(val);
                 _showPrefixIcon = true;
               });
             } else {
-              widget.onTag(val);
               setState(() {
                 _tagsStringContent.add(val);
               });
@@ -175,14 +177,15 @@ class _TextFieldTagsState extends State<TextFieldTags> {
             _textEditingController.clear();
 
             if (!_tagsStringContent.contains(lastLastTag)) {
-              if (!_showPrefixIcon) {
+              if (widget.onTag != null)
                 widget.onTag(lastLastTag);
+
+              if (!_showPrefixIcon) {
                 setState(() {
                   _tagsStringContent.add(lastLastTag);
                   _showPrefixIcon = true;
                 });
               } else {
-                widget.onTag(lastLastTag);
                 setState(() {
                   _tagsStringContent.add(lastLastTag);
                 });


### PR DESCRIPTION
Merging this PR will close #6 and will add a feature where the user can set an initial list of tags, which might have been added previously.

This is personally tested by me. 
And apart from implementing this feature, I've also updated the `README.md` accordingly and have modified the code a little bit (have made the if statements shorter). Also, I didn't notice while committing that Android studio has formatted the code, LMK if you want that like before.
LMK, if any further change is required from my end. :slightly_smiling_face: 