### PR TITLE
Add hashtag option

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,7 +42,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
           //[textFieldStyler] is required and shall not be null
           textFieldStyler: TextFieldStyler(
-
               //These are properties you can tweek for customization of the textfield
 
               // bool textFieldFilled = false,
@@ -77,6 +76,7 @@ class _MyHomePageState extends State<MyHomePage> {
               // BoxDecoration tagDecoration = const BoxDecoration(color: Color.fromARGB(255, 74, 137, 92)),
               // TextStyle tagTextStyle,
               // Icon tagCancelIcon = const Icon(Icons.cancel, size: 18.0, color: Colors.green)
+              // isHashTag: true,
               ),
           onTag: (tag) {
             //This give you tags entered

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -40,6 +40,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   ScrollController _scrollController = ScrollController();
   bool _showPrefixIcon = false;
   double _deviceWidth;
+  String _prefixIcon = "#";
 
   @override
   void initState() {
@@ -66,7 +67,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   List<Widget> get _getTags {
     List<Widget> _tags = [];
     for (var i = 0; i < _tagsStringContent.length; i++) {
-      String tagText = _tagsStringContent[i];
+      String tagText = widget.tagsStyler.isHashTag ?  "$_prefixIcon${_tagsStringContent[i]}" : _tagsStringContent[i];
       var tag = Container(
         padding: widget.tagsStyler.tagPadding,
         decoration: widget.tagsStyler.tagDecoration,

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -25,6 +25,9 @@ class TagsStyler {
   ///[tagCancelIcon] apply your own icon, if you want, to delete the icon
   final Widget tagCancelIcon;
 
+  ///Enable or disable the # prefix icon
+  final bool isHashTag;
+
   TagsStyler({
     this.tagTextPadding = const EdgeInsets.all(0.0),
     this.tagCancelIconPadding = const EdgeInsets.only(left: 1.0),
@@ -33,6 +36,7 @@ class TagsStyler {
     this.tagDecoration =
         const BoxDecoration(color: Color.fromARGB(255, 74, 137, 92)),
     this.tagTextStyle,
+    this.isHashTag = false,
     this.tagCancelIcon = const Icon(
       Icons.cancel,
       size: 18.0,


### PR DESCRIPTION
While developing an app, I devised it from what designers asked me to add #.
As shown in the picture below, if you change isHashTag to True, # is added in front of the tag.

![capture](https://user-images.githubusercontent.com/55731606/110074866-3f5cae80-7dc5-11eb-9a66-b34766d778c3.PNG)

We politely ask for your  review.