### PR TITLE
Implementing backspace deletion

### DIFF
--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -212,13 +212,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
             });
           }
 
-          if (_tagsStringContent.length == 0) {
-            _textEditingController.text = "";
-          } else {
-            _textEditingController.text = "  ";
-            _textEditingController.selection = TextSelection.fromPosition(
-                TextPosition(offset: _textEditingController.text.length));
-          }
+          _onFocusChange();
           return;
         }
 

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -171,24 +171,22 @@ class _TextFieldTagsState extends State<TextFieldTags> {
             : null,
       ),
       onSubmitted: (value) {
-        if(value != "  ") {
-          var val = value.trim().toLowerCase();
-          if (value.length > 0) {
-            _textEditingController.clear();
-            if (!_tagsStringContent.contains(val)) {
-              widget.onTag(val);
-              if (!_showPrefixIcon) {
-                setState(() {
-                  _tagsStringContent.add(val);
-                  _showPrefixIcon = true;
-                });
-              } else {
-                setState(() {
-                  _tagsStringContent.add(val);
-                });
-              }
-              this._animateTransition();
+        var val = value.trim().toLowerCase();
+        if (val.length > 0) {
+          _textEditingController.clear();
+          if (!_tagsStringContent.contains(val)) {
+            widget.onTag(val);
+            if (!_showPrefixIcon) {
+              setState(() {
+                _tagsStringContent.add(val);
+                _showPrefixIcon = true;
+              });
+            } else {
+              setState(() {
+                _tagsStringContent.add(val);
+              });
             }
+            this._animateTransition();
           }
         }
       },

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -38,11 +38,13 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   List<String> _tagsStringContent = [];
   TextEditingController _textEditingController = TextEditingController();
   ScrollController _scrollController = ScrollController();
+  FocusNode _focusNode = FocusNode();
   bool _showPrefixIcon = false;
   double _deviceWidth;
   @override
   void initState() {
     super.initState();
+    _focusNode.addListener(_onFocusChange);
     if (widget.initialTags != null && widget.initialTags.isNotEmpty) {
       _showPrefixIcon = true;
       _tagsStringContent = widget.initialTags;
@@ -60,6 +62,16 @@ class _TextFieldTagsState extends State<TextFieldTags> {
     super.dispose();
     _textEditingController.dispose();
     _scrollController.dispose();
+  }
+
+  void _onFocusChange() {
+    if (_tagsStringContent.length == 0) {
+      _textEditingController.text = "";
+    } else {
+      _textEditingController.text = "  ";
+      _textEditingController.selection = TextSelection.fromPosition(
+          TextPosition(offset: _textEditingController.text.length));
+    }
   }
 
   List<Widget> get _getTags {
@@ -121,6 +133,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   @override
   Widget build(BuildContext context) {
     return TextField(
+      focusNode: _focusNode,
       controller: _textEditingController,
       autocorrect: false,
       cursorColor: widget.textFieldStyler.cursorColor,
@@ -158,22 +171,24 @@ class _TextFieldTagsState extends State<TextFieldTags> {
             : null,
       ),
       onSubmitted: (value) {
-        var val = value.trim().toLowerCase();
-        if (value.length > 0) {
-          _textEditingController.clear();
-          if (!_tagsStringContent.contains(val)) {
-            widget.onTag(val);
-            if (!_showPrefixIcon) {
-              setState(() {
-                _tagsStringContent.add(val);
-                _showPrefixIcon = true;
-              });
-            } else {
-              setState(() {
-                _tagsStringContent.add(val);
-              });
+        if(value != "  ") {
+          var val = value.trim().toLowerCase();
+          if (value.length > 0) {
+            _textEditingController.clear();
+            if (!_tagsStringContent.contains(val)) {
+              widget.onTag(val);
+              if (!_showPrefixIcon) {
+                setState(() {
+                  _tagsStringContent.add(val);
+                  _showPrefixIcon = true;
+                });
+              } else {
+                setState(() {
+                  _tagsStringContent.add(val);
+                });
+              }
+              this._animateTransition();
             }
-            this._animateTransition();
           }
         }
       },
@@ -214,9 +229,6 @@ class _TextFieldTagsState extends State<TextFieldTags> {
             _textEditingController.clear();
             if (!_tagsStringContent.contains(lastLastTag)) {
               widget.onTag(lastLastTag);
-              _textEditingController.text = "  ";
-              _textEditingController.selection = TextSelection.fromPosition(
-                  TextPosition(offset: _textEditingController.text.length));
               if (!_showPrefixIcon) {
                 setState(() {
                   _tagsStringContent.add(lastLastTag);
@@ -227,8 +239,11 @@ class _TextFieldTagsState extends State<TextFieldTags> {
                   _tagsStringContent.add(lastLastTag);
                 });
               }
-              this._animateTransition();
             }
+            _textEditingController.text = "  ";
+            _textEditingController.selection = TextSelection.fromPosition(
+                TextPosition(offset: _textEditingController.text.length));
+            this._animateTransition();
           }
         }
       },

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -30,6 +30,7 @@ class TextFieldTags extends StatefulWidget {
         assert(onDelete != null && onTag != null,
             'onDelete and onTag should not be null'),
         super(key: key);
+
   @override
   _TextFieldTagsState createState() => _TextFieldTagsState();
 }
@@ -41,6 +42,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   FocusNode _focusNode = FocusNode();
   bool _showPrefixIcon = false;
   double _deviceWidth;
+
   @override
   void initState() {
     super.initState();
@@ -77,7 +79,9 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   List<Widget> get _getTags {
     List<Widget> _tags = [];
     for (var i = 0; i < _tagsStringContent.length; i++) {
-      String tagText = widget.tagsStyler.showHashtag ?  "#${_tagsStringContent[i]}" : _tagsStringContent[i];
+      String tagText = widget.tagsStyler.showHashtag
+          ? "#${_tagsStringContent[i]}"
+          : _tagsStringContent[i];
       var tag = Container(
         padding: widget.tagsStyler.tagPadding,
         decoration: widget.tagsStyler.tagDecoration,
@@ -109,6 +113,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
                       _tagsStringContent.remove(_tagsStringContent[i]);
                     });
                   }
+                  _onFocusChange();
                 },
                 child: widget.tagsStyler.tagCancelIcon,
               ),
@@ -134,6 +139,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
   Widget build(BuildContext context) {
     return TextField(
       focusNode: _focusNode,
+      enableInteractiveSelection: false,
       controller: _textEditingController,
       autocorrect: false,
       cursorColor: widget.textFieldStyler.cursorColor,
@@ -211,7 +217,6 @@ class _TextFieldTagsState extends State<TextFieldTags> {
                   .remove(_tagsStringContent[_tagsStringContent.length - 1]);
             });
           }
-
           _onFocusChange();
           return;
         }
@@ -232,9 +237,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
                 });
               }
             }
-            _textEditingController.text = "  ";
-            _textEditingController.selection = TextSelection.fromPosition(
-                TextPosition(offset: _textEditingController.text.length));
+            _onFocusChange();
             this._animateTransition();
           }
         }

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -182,13 +182,41 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         var lastLastTag =
             splitedTagsList[splitedTagsList.length - 2].trim().toLowerCase();
 
+        if (value == " ") {
+          if (widget.onDelete != null)
+            widget.onDelete(_tagsStringContent[_tagsStringContent.length - 1]);
+
+          if (_tagsStringContent.length == 1 && _showPrefixIcon) {
+            setState(() {
+              _tagsStringContent
+                  .remove(_tagsStringContent[_tagsStringContent.length - 1]);
+              _showPrefixIcon = false;
+            });
+          } else {
+            setState(() {
+              _tagsStringContent
+                  .remove(_tagsStringContent[_tagsStringContent.length - 1]);
+            });
+          }
+
+          if (_tagsStringContent.length == 0) {
+            _textEditingController.text = "";
+          } else {
+            _textEditingController.text = "  ";
+            _textEditingController.selection = TextSelection.fromPosition(
+                TextPosition(offset: _textEditingController.text.length));
+          }
+          return;
+        }
+
         if (value.contains(" ")) {
           if (lastLastTag.length > 0) {
             _textEditingController.clear();
-
             if (!_tagsStringContent.contains(lastLastTag)) {
               widget.onTag(lastLastTag);
-
+              _textEditingController.text = "  ";
+              _textEditingController.selection = TextSelection.fromPosition(
+                  TextPosition(offset: _textEditingController.text.length));
               if (!_showPrefixIcon) {
                 setState(() {
                   _tagsStringContent.add(lastLastTag);


### PR DESCRIPTION
This time, I implemented backspace deletion. 
It's the desired feature that tags gets deleted when you press backspace button.
but flutter doesn`t have the function to detect the soft backspace button.
So I did the trick like the space add function.
Execute when the param value of onChanged function enters once space.
Since this part can conflict with the space add-in, the form's starting value is always two spaces.
When the TextField focuses, it is always fixed with two spaces to avoid errors in the user's space position via focusNode.
The problem here occurs when the user forcibly moves the cursor of the textfield.
However, I thought that people would seldom deliberately change the position of the cursor.
Below is a demo video.

![test](https://user-images.githubusercontent.com/55731606/110263984-8fbd5180-7ffb-11eb-868a-3a464131a0a1.gif)

I'm sorry for my poor English.
Please let me know if there is any problem with the code.