### PR TITLE
Optional "allowSpaces" argument to prevent splitting on spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To start using this widget, you will need to first import the package inside you
 To use this widget, 
 1. `import 'package:textfield_tags/textfield_tags.dart';` inside your dart file
 2. Call the widget `TextFieldTags()`. 
-3. The widget takes in 5 arguments: `TagsStyler`, `TextFieldStyler`, `onTag`, `onDelete`, and `initialTags`. Note that `TagsStyler`, `TextFieldStyler`, `onTag`, `onDelete` should not be null.
+3. The widget takes in 6 arguments: `TagsStyler`, `TextFieldStyler`, `onTag`, `onDelete`, `initialTags` and `allowSpaces`. Note that `TagsStyler`, `TextFieldStyler`, `onTag`, `onDelete` should not be null.
 You can investigate the properties of `TagsStyler` and `TextFieldStyler` for more customizations if you choose to do so.
 
 ### When you want to use it, call the `TextFieldTags()` as bellow examples show

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -18,7 +18,7 @@ class TextFieldTags extends StatefulWidget {
   ///[initialTags] are optional initial tags you can enter
   final List<String> initialTags;
   
-  ///[textFieldStyler] must not be [null]
+  ///[allowSpaces] can be set to true to prevent tags from being added when entering space. Defaults to false.
   final bool allowSpaces;
 
   const TextFieldTags({

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -8,7 +8,7 @@ class TextFieldTags extends StatefulWidget {
 
   ///[textFieldStyler] must not be [null]
   final TextFieldStyler textFieldStyler;
-
+  
   ///[onTag] must not be [null] and should be implemented
   final void Function(String tag) onTag;
 
@@ -17,6 +17,9 @@ class TextFieldTags extends StatefulWidget {
 
   ///[initialTags] are optional initial tags you can enter
   final List<String> initialTags;
+  
+  ///[textFieldStyler] must not be [null]
+  final bool allowSpaces;
 
   const TextFieldTags({
     Key key,
@@ -25,6 +28,7 @@ class TextFieldTags extends StatefulWidget {
     @required this.onTag,
     @required this.onDelete,
     this.initialTags,
+    this.allowSpaces = false,
   })  : assert(tagsStyler != null && textFieldStyler != null,
             'tagsStyler and textFieldStyler should not be null'),
         assert(onDelete != null && onTag != null,
@@ -178,28 +182,30 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         }
       },
       onChanged: (value) {
-        var splitedTagsList = value.split(" ");
-        var lastLastTag =
-            splitedTagsList[splitedTagsList.length - 2].trim().toLowerCase();
+        if(!widget.allowSpaces){
+          var splitedTagsList = value.split(" ");
+          var lastLastTag =
+              splitedTagsList[splitedTagsList.length - 2].trim().toLowerCase();
 
-        if (value.contains(" ")) {
-          if (lastLastTag.length > 0) {
-            _textEditingController.clear();
+          if (value.contains(" ")) {
+            if (lastLastTag.length > 0) {
+              _textEditingController.clear();
 
-            if (!_tagsStringContent.contains(lastLastTag)) {
-              widget.onTag(lastLastTag);
+              if (!_tagsStringContent.contains(lastLastTag)) {
+                widget.onTag(lastLastTag);
 
-              if (!_showPrefixIcon) {
-                setState(() {
-                  _tagsStringContent.add(lastLastTag);
-                  _showPrefixIcon = true;
-                });
-              } else {
-                setState(() {
-                  _tagsStringContent.add(lastLastTag);
-                });
+                if (!_showPrefixIcon) {
+                  setState(() {
+                    _tagsStringContent.add(lastLastTag);
+                    _showPrefixIcon = true;
+                  });
+                } else {
+                  setState(() {
+                    _tagsStringContent.add(lastLastTag);
+                  });
+                }
+                this._animateTransition();
               }
-              this._animateTransition();
             }
           }
         }


### PR DESCRIPTION
Some of the tags entered in my app require spaces, it would be great if we could support this through an extra argument. I've added an optional argument that defaults to false in order to keep the current behavior by default.