### PR TITLE
Add new showHelper option

### DIFF
--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -34,6 +34,9 @@ class TextFieldTags extends StatefulWidget {
   ///Enter optional String separators to split tags. Default is [","," "]
   final List<String>? textSeparators;
 
+  ///Should helper text be displayed
+  final bool showHelper;
+  
   TextFieldTags({
     Key? key,
     this.tagsDistanceFromBorderEnd = 0.725,
@@ -42,6 +45,7 @@ class TextFieldTags extends StatefulWidget {
     this.validator,
     this.initialTags = const [],
     this.textSeparators = const [" ", ","],
+    this.showHelper = true,
     required this.tagsStyler,
     required this.textFieldStyler,
     required this.onTag,

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -161,9 +161,10 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         icon: widget.textFieldStyler.icon,
         contentPadding: widget.textFieldStyler.contentPadding,
         isDense: widget.textFieldStyler.isDense,
-        helperText: _showValidator
+        helperText: widget.showhelper ? _showValidator
             ? _validatorMessage
-            : widget.textFieldStyler.helperText,
+            : widget.textFieldStyler.helperText
+            : null,
         helperStyle: _showValidator
             ? const TextStyle(color: Colors.red)
             : widget.textFieldStyler.helperStyle,

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -161,7 +161,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         icon: widget.textFieldStyler.icon,
         contentPadding: widget.textFieldStyler.contentPadding,
         isDense: widget.textFieldStyler.isDense,
-        helperText: widget.showhelper ? _showValidator
+        helperText: widget.showHelper ? _showValidator
             ? _validatorMessage
             : widget.textFieldStyler.helperText
             : null,


### PR DESCRIPTION
New  bool `showHelper` option added incase we do not want to show helper text under the text input area.  

Right now, `widget.textFieldStyler.helperText` is a String, so it will not take `null` as an option choice.  In order to make helperText blank (and not add in empty space under the textfield) it has to be `null`, setting it to '' will still leave an empty block of space.

By adding in the `showHelper` option, we can now choose to separately make it `null`

Thank you