### PR TITLE
Expose TextEditingController

### DIFF
--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -34,6 +34,9 @@ class TextFieldTags extends StatefulWidget {
   ///Enter optional String separators to split tags. Default is [","," "]
   final List<String>? textSeparators;
 
+  ///Should helper text be displayed
+  final bool showHelper;
+  
   TextFieldTags({
     Key? key,
     this.tagsDistanceFromBorderEnd = 0.725,
@@ -42,6 +45,7 @@ class TextFieldTags extends StatefulWidget {
     this.validator,
     this.initialTags = const [],
     this.textSeparators = const [" ", ","],
+    this.showHelper = true,
     required this.tagsStyler,
     required this.textFieldStyler,
     required this.onTag,

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -161,9 +161,10 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         icon: widget.textFieldStyler.icon,
         contentPadding: widget.textFieldStyler.contentPadding,
         isDense: widget.textFieldStyler.isDense,
-        helperText: _showValidator
+        helperText: widget.showhelper ? _showValidator
             ? _validatorMessage
-            : widget.textFieldStyler.helperText,
+            : widget.textFieldStyler.helperText
+            : null,
         helperStyle: _showValidator
             ? const TextStyle(color: Colors.red)
             : widget.textFieldStyler.helperStyle,

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -49,7 +49,7 @@ class TextFieldTags extends StatefulWidget {
     this.initialTags = const [],
     this.textSeparators = const [" ", ","],
     this.showHelper = true,
-    this.controller,
+    this.controller = TextEditingController(),
     required this.tagsStyler,
     required this.textFieldStyler,
     required this.onTag,
@@ -75,7 +75,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
     _showValidator = false;
     _tagsStringContents = Set.from(widget.initialTags!);
     _showPrefixIcon = _tagsStringContents!.length > 0 ? true : false;
-    _textEditingController = widget.controller ?? TextEditingController();
+    _textEditingController = widget.controller;
     _scrollController = ScrollController();
   }
 

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -161,7 +161,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
         icon: widget.textFieldStyler.icon,
         contentPadding: widget.textFieldStyler.contentPadding,
         isDense: widget.textFieldStyler.isDense,
-        helperText: widget.showhelper ? _showValidator
+        helperText: widget.showHelper ? _showValidator
             ? _validatorMessage
             : widget.textFieldStyler.helperText
             : null,

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -38,7 +38,7 @@ class TextFieldTags extends StatefulWidget {
   final bool showHelper;
   
   ///Should helper text be displayed
-  final TextEditingController? controller = TextEditingController();
+  final TextEditingController? controller;
   
   TextFieldTags({
     Key? key,
@@ -75,7 +75,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
     _showValidator = false;
     _tagsStringContents = Set.from(widget.initialTags!);
     _showPrefixIcon = _tagsStringContents!.length > 0 ? true : false;
-    _textEditingController = widget.controller;
+    _textEditingController = widget.controller ?? TextEditingController();
     _scrollController = ScrollController();
   }
 

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -49,7 +49,7 @@ class TextFieldTags extends StatefulWidget {
     this.initialTags = const [],
     this.textSeparators = const [" ", ","],
     this.showHelper = true,
-    this.controller = TextEditingController(),
+    this.controller = const TextEditingController(),
     required this.tagsStyler,
     required this.textFieldStyler,
     required this.onTag,

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -37,6 +37,9 @@ class TextFieldTags extends StatefulWidget {
   ///Should helper text be displayed
   final bool showHelper;
   
+  ///Should helper text be displayed
+  final TextEditingController controller;
+  
   TextFieldTags({
     Key? key,
     this.tagsDistanceFromBorderEnd = 0.725,
@@ -46,6 +49,7 @@ class TextFieldTags extends StatefulWidget {
     this.initialTags = const [],
     this.textSeparators = const [" ", ","],
     this.showHelper = true,
+    this.controller,
     required this.tagsStyler,
     required this.textFieldStyler,
     required this.onTag,
@@ -71,7 +75,7 @@ class _TextFieldTagsState extends State<TextFieldTags> {
     _showValidator = false;
     _tagsStringContents = Set.from(widget.initialTags!);
     _showPrefixIcon = _tagsStringContents!.length > 0 ? true : false;
-    _textEditingController = TextEditingController();
+    _textEditingController = widget.controller ?? TextEditingController();
     _scrollController = ScrollController();
   }
 

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -38,7 +38,7 @@ class TextFieldTags extends StatefulWidget {
   final bool showHelper;
   
   ///Should helper text be displayed
-  final TextEditingController controller;
+  final TextEditingController? controller = TextEditingController();
   
   TextFieldTags({
     Key? key,
@@ -49,7 +49,7 @@ class TextFieldTags extends StatefulWidget {
     this.initialTags = const [],
     this.textSeparators = const [" ", ","],
     this.showHelper = true,
-    this.controller = const TextEditingController(),
+    this.controller,
     required this.tagsStyler,
     required this.textFieldStyler,
     required this.onTag,


### PR DESCRIPTION
Allow us to enter a `TextEditingController()` from the outside so we can more accurately deal with the textfield, which is a must for a textfield
