### PR TITLE
Dispose TextfieldTagsController only after disposing its elements

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -178,9 +178,9 @@ class TextfieldTagsController extends TextfieldTagsNotifier {
 
   @override
   void dispose() {
-    super.dispose();
     textEditingController!.dispose();
     focusNode!.dispose();
     scrollController.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
See https://api.flutter.dev/flutter/widgets/State/dispose.html for reference:
> Implementations of this method should end with a call to the inherited method, as in super.dispose().